### PR TITLE
Replace test for step_by adaptor 

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -306,13 +306,12 @@ fn main() {
     cg_demo();
 }
 
-// Unit Tests Module
+/// Unit Tests Module
 #[cfg(test)]
 mod tests {
     use super::*;
 
     #[test]
-    // Test the step_by adaptor
     fn step_by_test() {
         let v = vec![0, 1, 2, 3, 4, 5, 6, 7, 8, 9];
         let iter = convert(v);


### PR DESCRIPTION
The test for the step_by adaptor is replaced with a simpler one that does not rely on CGIterable. The test passes.