### PR TITLE
TimedIterable now notes also start_time relative to its creation.

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -295,6 +295,9 @@ where
     last_item
 }
 
+/// Wrap each value of a streaming iterator with the durations:
+/// - between the call to this function and start of the value's computation
+/// - it took to calculate that value
 fn time<I, T>(it: I) -> TimedIterable<I, T>
 where
     I: Sized + StreamingIterator<Item = T>,
@@ -587,7 +590,7 @@ mod tests {
                 durations.push(duration.as_nanos());
             },
         );
-        while let Some(_x) = cg_print_iter.next() {};
+        while let Some(_x) = cg_print_iter.next() {}
         println!("Start times: {:?}", start_times);
         println!("Durations: {:?}", durations);
         let start_times = rcarr1(&start_times).map(|i| *i as f64);


### PR DESCRIPTION
Also, its `last` is renamed `current`.

# Intent:

Enable plots of when different results are obtained (including any overhead) in addition to the time taken by the underlying iterable.

# Validation:

- [x] Are changes covered by tests so we know existing functionality is not broken?
Added a couple of tests, one for the pre-existing functionality.
- [x] Is the new functionality covered by tests?
- [ ] For functionality that is impractical to test
  - [x] is there a demo?
  - [x] does it look like you'd expect?
  
# State of PR
- [x] Ready to merge on master
- [x] CI passes
- [x] Code is documented via rustdoc commments for readers post-landing
- [x] Changes that need explanation pre-landing (why make the change) have self-review comments
