### PR TITLE
Move utility function from lib test module to utils

### DIFF
--- a/src/utils.rs
+++ b/src/utils.rs
@@ -1,5 +1,9 @@
 use crate::algorithms::cg_method::*;
+use crate::*;
 use ndarray::{rcarr1, rcarr2};
+use std::iter;
+
+/// Utility Functions for the Conjugate Gradient Method
 
 /// A linear system, ax-b=0, to be solved iteratively, with an optional initial solution.
 #[derive(Clone, Debug)]
@@ -30,6 +34,36 @@ pub fn make_3x3_psd_system(m: M, b: V) -> LinearSystem {
         b: b,
         x0: None,
     }
+}
+
+/// Utility Functions for Weighted Reservoir Sampling
+
+/// utility function for testing ReservoirIterable
+pub fn generate_stream_with_constant_probability(
+    stream_length: usize,
+    capacity: usize,
+    probability: f64,
+    initial_weight: f64,
+    initial_value: usize,
+    final_value: usize,
+) -> impl Iterator<Item = WeightedDatum<usize>> {
+    // Create capacity of items with initial weight.
+    let initial_iter = iter::repeat(new_datum(initial_value, initial_weight)).take(capacity);
+    if capacity > stream_length {
+        panic!("Capacity must be less than or equal to stream length.");
+    }
+    let final_iter =
+        iter::repeat(new_datum(final_value, initial_weight)).take(stream_length - capacity);
+    let mut power = 0i32;
+    let mapped = final_iter.map(move |wd| {
+        power += 1;
+        new_datum(
+            wd.value,
+            initial_weight * probability / (1.0 - probability).powi(power),
+        )
+    });
+    let stream = initial_iter.chain(mapped);
+    stream
 }
 
 pub fn expose_w(count: &f64) -> f64 {


### PR DESCRIPTION
Move utility function, generate_stream_with_constant_probability, in lib test module to utils.rs and switch to using usize for its initial and final values.



# Intent:

- [x] Explain here what the goal is, so reviewer can read the implementation and judge whether that goal is achieved.
- [ ] The reason for this change is to be able to use the function for both tests in the lib.rs/tests module and in examples. The architecture remains acyclic at the level of modules but now is cyclic at the level of files.

# Validation:

- [x] Are changes covered by tests so we know existing functionality is not broken?
- [x] Is the new functionality covered by tests?
- [ ] For functionality that is impractical to test
  - [ ] is there a demo?
  - [ ] does it look like you'd expect?
  
# State of PR
- [x] Ready to merge on master
- [x] CI passes
- [ ] Code is documented via rustdoc commments for readers post-landing
- [ ] Changes that need explanation pre-landing (why make the change) have self-review comments
