### PR TITLE
Fix bug in write_yaml_object. Last \n is pushed onto string explicitly.

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -384,6 +384,7 @@ where
     emitter
         .dump(&yaml_item)
         .expect("Could not convert item to yaml object.");
+    out_str.push_str("\n");
     file_writer
         .write_all(out_str.as_bytes())
         .expect("Writing value to file failed.");
@@ -889,7 +890,7 @@ mod tests {
         // let docs = YamlLoader::load_from_str(&contents).expect("Could not load contents of file to yaml object.");
         // Remove the file for the next run of the test.
         std::fs::remove_file(test_file_path).expect("Could not remove data file for test.");
-        assert_eq!("---\n0---\n1---\n2---\n3", &contents);
+        assert_eq!("---\n0\n---\n1\n---\n2\n---\n3\n", &contents);
     }
 
     /// ToYamlIterable Test: Write stream of vecs to yaml
@@ -915,7 +916,7 @@ mod tests {
             .read_to_string(&mut contents)
             .expect("Could not read data from file.");
         std::fs::remove_file(test_file_path).expect("Could not remove data file for test.");
-        assert_eq!("---\n- 0\n- 1---\n- 2\n- 3", &contents);
+        assert_eq!("---\n- 0\n- 1\n---\n- 2\n- 3\n", &contents);
     }
 
     /// Test that write_yaml_object works on Numbered.
@@ -934,7 +935,7 @@ mod tests {
             .expect("Could not open test file.");
         write_yaml_object(&num, &mut file).expect("write_yaml_object Failed.");
         let contents = utils::read_yaml_to_string(test_file_path).expect("Could not read file.");
-        assert_eq!("---\n- 0\n- 0.1", &contents);
+        assert_eq!("---\n- 0\n- 0.1\n", &contents);
     }
 
     // Test that enumerate() adaptor produces items wrapped in a Numbered struct with the enumeration count.
@@ -1002,7 +1003,7 @@ mod tests {
             .read_to_string(&mut contents)
             .expect("Could not read data from file.");
         std::fs::remove_file(test_file_path).expect("Could not remove data file for test.");
-        assert_eq!("---\n- - 0\n  - 3\n- - 1\n  - 6\n- - 2\n  - 9---\n- - 0\n  - 5\n- - 1\n  - 10\n- - 2\n  - 15", &contents);
+        assert_eq!("---\n- - 0\n  - 3\n- - 1\n  - 6\n- - 2\n  - 9\n---\n- - 0\n  - 5\n- - 1\n  - 10\n- - 2\n  - 15\n", &contents);
     }
 
     /// Tests for the ReservoirIterable adaptor

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -87,6 +87,7 @@ fn enumerate_reservoirs_to_yaml_test() {
         println!("{:?}", t);
     }
     let contents = utils::read_yaml_to_string(test_file_path).expect("Could not read file.");
-    let output = String::from("---\n- 0\n- - 0\n  - 0---\n- 1\n- - 0\n  - 1---\n- 2\n- - 1\n  - 1");
+    let output =
+        String::from("---\n- 0\n- - 0\n  - 0\n---\n- 1\n- - 0\n  - 1\n---\n- 2\n- - 1\n  - 1\n");
     assert_eq!(contents, output);
 }


### PR DESCRIPTION
# Intent:

- [x] Writing to yaml did not return after the last line, leading to incorrect formats. This is fixed.

# Validation:

- [x] Are changes covered by tests so we know existing functionality is not broken?
- [x] Is the new functionality covered by tests?
- [ ] For functionality that is impractical to test
  - [ ] is there a demo?
  - [ ] does it look like you'd expect?
  
# State of PR
- [x] Ready to merge on master
- [ ] CI passes
- [ ] Code is documented via rustdoc commments for readers post-landing
- [ ] Changes that need explanation pre-landing (why make the change) have self-review comments
