### PR TITLE
Replace mean_and_max_index closure with simpler version using fold.

### DIFF
--- a/examples/reservoir_histogram_animation.rs
+++ b/examples/reservoir_histogram_animation.rs
@@ -77,25 +77,11 @@ fn write_reservoir_visualizations_data_to_yaml(
 
     // This closure converts items from reservoirs to Numbered{max_index, Some(reservoir_mean)}
     let reservoir_mean_and_max_index = |reservoir: &Vec<Numbered<f64>>| -> Numbered<f64> {
-        let mean_and_max_index = reservoir.iter().scan(
-            Numbered {
-                count: 0,
-                item: Some(0.),
-            },
-            |state, x| {
-                state.count = cmp::max(state.count, x.count);
-                if let Some(partial_sum) = (*state).item {
-                    *state = Numbered {
-                        count: state.count,
-                        item: Some(partial_sum + x.item.unwrap()),
-                    }
-                }
-                Some(state.clone())
-            },
-        );
-        let result = &mean_and_max_index.last();
-        let mean = result.as_ref().unwrap().item.unwrap() / (capacity as f64);
-        let max_index = result.as_ref().unwrap().count;
+        let result = reservoir.iter().fold((0, 0.), |acc, x| {
+            (cmp::max(acc.0, x.count), acc.1 + x.item.unwrap())
+        });
+        let max_index = result.0;
+        let mean = result.1 / (capacity as f64);
         Numbered {
             count: max_index,
             item: Some(mean),


### PR DESCRIPTION
# Intent:

- [x] Explain here what the goal is, so reviewer can read the implementation and judge whether that goal is achieved.
- Simplify the closure used to compute the max_index and mean of each reservoir.

# Validation:

- [ ] Are changes covered by tests so we know existing functionality is not broken?
- [ ] Is the new functionality covered by tests?
- [x] For functionality that is impractical to test
  - [x] is there a demo?
  - [x] does it look like you'd expect?
  
# State of PR
- [x] Ready to merge on master
- [ ] CI passes
- [ ] Code is documented via rustdoc commments for readers post-landing
- [ ] Changes that need explanation pre-landing (why make the change) have self-review comments
