### PR TITLE
Implement Yaml writer for annotated result

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -912,15 +912,20 @@ mod tests {
     /// This shows that that write_yaml_object works on a custom struct.
     #[test]
     fn annotated_result_to_yaml_test() {
-        let ann = AnnotatedResult{result: 0, annotation: "zero".to_string()};
+        let ann = AnnotatedResult {
+            result: 0,
+            annotation: "zero".to_string(),
+        };
         let test_file_path = "./annotated_result_test.yaml";
         let mut file = OpenOptions::new()
             .append(true)
             .create(true)
             .open(test_file_path)
             .expect("Could not open test file.");
-        write_yaml_object(&ann, &mut file).expect(&format!("write_yaml_object Failed for {}", test_file_path));
-        let contents = utils::read_yaml_to_string(test_file_path).expect(&format!("Could not read {}", test_file_path));
+        write_yaml_object(&ann, &mut file)
+            .expect(&format!("write_yaml_object Failed for {}", test_file_path));
+        let contents = utils::read_yaml_to_string(test_file_path)
+            .expect(&format!("Could not read {}", test_file_path));
         assert_eq!("---\n- 0\n- zero\n", &contents);
     }
 


### PR DESCRIPTION
# Intent:

- [x] Explain here what the goal is, so reviewer can read the implementation and judge whether that goal is achieved.
- Impl YamlDataType for AnnotatedResult so that it can be written to Yaml.

# Validation:

- [x] Are changes covered by tests so we know existing functionality is not broken?
- [x] Is the new functionality covered by tests?
- [ ] For functionality that is impractical to test
  - [ ] is there a demo?
  - [ ] does it look like you'd expect?
  
# State of PR
- [x] Ready to merge on master
- [ ] CI passes
- [ ] Code is documented via rustdoc commments for readers post-landing
- [ ] Changes that need explanation pre-landing (why make the change) have self-review comments
