### PR TITLE
Fixup the ConjugateGradient constructor and adapt blog code

### DIFF
--- a/examples/conjugate_gradient_method.rs
+++ b/examples/conjugate_gradient_method.rs
@@ -2,7 +2,7 @@ extern crate eigenvalues;
 extern crate nalgebra as na;
 use streaming_iterator::*;
 
-use iterative_methods::conjugate_gradient::{conjugate_gradient, ConjugateGradient};
+use iterative_methods::conjugate_gradient::ConjugateGradient;
 use iterative_methods::utils::make_3x3_pd_system_2;
 use iterative_methods::*;
 
@@ -35,7 +35,7 @@ fn cg_demo() {
     let optimum = rcarr1(&[-4.0, 6., -4.]);
 
     // Initialize the conjugate gradient solver on this problem
-    let cg_iter = conjugate_gradient(&p);
+    let cg_iter = ConjugateGradient::for_problem(&p);
 
     // Cap the number of iterations.
     let cg_iter = cg_iter.take(80);

--- a/src/algorithms.rs
+++ b/src/algorithms.rs
@@ -30,7 +30,7 @@ mod tests {
     }
 
     pub fn show_progress(p: LinearSystem) {
-        let cg_iter = conjugate_gradient(&p).take(20);
+        let cg_iter = ConjugateGradient::for_problem(&p).take(20);
         let mut cg_print_iter = inspect(cg_iter, |result| {
             //println!("result: {:?}", result);
             let res = result.a.dot(&result.solution) - &result.b;

--- a/src/algorithms.rs
+++ b/src/algorithms.rs
@@ -1,4 +1,4 @@
-pub use crate::conjugate_gradient::conjugate_gradient;
+pub use crate::conjugate_gradient::ConjugateGradient;
 use ndarray::ArcArray1;
 use ndarray::ArcArray2;
 pub type S = f64;
@@ -9,7 +9,7 @@ pub type V = ArcArray1<S>;
 #[cfg(test)]
 mod tests {
 
-    use crate::conjugate_gradient::conjugate_gradient;
+    use crate::conjugate_gradient::ConjugateGradient;
     use crate::inspect;
     use crate::last;
     use crate::utils::make_3x3_pd_system_1;
@@ -25,7 +25,7 @@ mod tests {
     use streaming_iterator::StreamingIterator;
 
     pub fn solve_approximately(p: LinearSystem) -> V {
-        let solution = conjugate_gradient(&p).take(20);
+        let solution = ConjugateGradient::for_problem(&p).take(20);
         last(solution.map(|s| s.x_k.clone())).expect("CGIterable should always return a solution.")
     }
 

--- a/src/conjugate_gradient.rs
+++ b/src/conjugate_gradient.rs
@@ -75,35 +75,37 @@ pub struct ConjugateGradient {
     pub pap_km: S,
 }
 
-/// Initialize a conjugate gradient iterative solver
-pub fn conjugate_gradient(p: &LinearSystem) -> ConjugateGradient {
-    let x_0 = match &p.x0 {
-        Some(x) => x.clone(),
-        None => ArrayBase::zeros(p.a.shape()[0]),
-    };
+impl ConjugateGradient {
+    /// Initialize a conjugate gradient iterative solver to solve linear system `p`.
+    pub fn for_problem(p: &LinearSystem) -> ConjugateGradient {
+        let x_0 = match &p.x0 {
+            Some(x) => x.clone(),
+            None => ArrayBase::zeros(p.a.shape()[0]),
+        };
 
-    // Set r_0 = A*x_0 - b and p_0 =-r_0, k=0
-    let r_k = (&p.a.dot(&x_0) - &p.b).to_shared();
-    let r_k2 = r_k.dot(&r_k);
-    let r_km2 = NAN;
-    let p_k = -r_k.clone();
-    let ap_k = p.a.dot(&p_k).to_shared();
-    let pap_k = p_k.dot(&ap_k);
-    let pap_km = NAN;
-    ConjugateGradient {
-        x_k: x_0.clone(),
-        solution: x_0,
-        a: p.a.clone(),
-        b: p.b.clone(),
-        r_k,
-        r_k2,
-        r_km2,
-        p_k,
-        ap_k,
-        pap_k,
-        pap_km,
-        alpha_k: NAN,
-        beta_k: NAN,
+        // Set r_0 = A*x_0 - b and p_0 =-r_0, k=0
+        let r_k = (&p.a.dot(&x_0) - &p.b).to_shared();
+        let r_k2 = r_k.dot(&r_k);
+        let r_km2 = NAN;
+        let p_k = -r_k.clone();
+        let ap_k = p.a.dot(&p_k).to_shared();
+        let pap_k = p_k.dot(&ap_k);
+        let pap_km = NAN;
+        ConjugateGradient {
+            x_k: x_0.clone(),
+            solution: x_0,
+            a: p.a.clone(),
+            b: p.b.clone(),
+            r_k,
+            r_k2,
+            r_km2,
+            p_k,
+            ap_k,
+            pap_k,
+            pap_km,
+            alpha_k: NAN,
+            beta_k: NAN,
+        }
     }
 }
 

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -1,7 +1,7 @@
 use crate::utils::{
     expose_w, generate_step_stream, make_3x3_pd_system_1, read_yaml_to_string, Counter,
 };
-use iterative_methods::algorithms::conjugate_gradient;
+use iterative_methods::algorithms::ConjugateGradient;
 use iterative_methods::*;
 extern crate streaming_iterator;
 use crate::streaming_iterator::*;
@@ -13,7 +13,7 @@ use rand_pcg::Pcg64;
 #[test]
 fn test_timed_iterable() {
     let p = make_3x3_pd_system_1();
-    let cg_iter = conjugate_gradient(&p).take(50);
+    let cg_iter = ConjugateGradient::for_problem(&p).take(50);
     let cg_timed_iter = time(cg_iter);
     let mut start_times = Vec::new();
     let mut durations = Vec::new();


### PR DESCRIPTION
# Intent:

- [ConjugateGradient constructor should be a static method](https://rust-lang.github.io/api-guidelines/predictability.html#constructors-are-static-inherent-methods-c-ctor)
- Clean up the blog demo output/code some

# Validation:

- [x] Are changes covered by tests so we know existing functionality is not broken?
- [x] Is the new functionality covered by tests?
- [x] For functionality that is impractical to test
  - [x] is there a demo?
  - [x] does it look like you'd expect?
  
# State of PR
- [x] Ready to merge on master
- [x] CI passes
- [x] Code is documented via rustdoc commments for readers post-landing
- [x] Changes that need explanation pre-landing (why make the change) have self-review comments
